### PR TITLE
ORM Configuration et mysql connexion to database hair-s-ball

### DIFF
--- a/back/ormconfig.js
+++ b/back/ormconfig.js
@@ -1,0 +1,16 @@
+require('dotenv').config()
+
+module.exports = {
+  type: 'mysql',
+  host: 'localhost',
+  port: 3306,
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: 'hair-s-ball',
+  entities: ['dist/**/*.entity{.ts,.js}'],
+  migrations: ['src/migration/**/*.ts'],
+  cli: {
+    migrationsDir: 'src/migration',
+  },
+  synchronize: true,
+}

--- a/front/.env.locale
+++ b/front/.env.locale
@@ -1,3 +1,0 @@
-NEXT_PUBLIC_API_URL=https://api.localhost:8000
-SECRET_KEY=secret
-```


### PR DESCRIPTION
Creation of the database in MySQL.
Creation of the “ormconfig” and “.env.local” file using dotenv so as not to expose yourself.
Set “synchronize: true” to create the tables automatically for development, but don't forget to set it to false in production.